### PR TITLE
Plog for a logger

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = cpr
 	url = https://github.com/libcpr/cpr.git
 	branch = 1.9.x
+[submodule "plog"]
+	path = plog
+	url = https://github.com/SergiusTheBest/plog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ endif()
 add_subdirectory(cpr)
 add_subdirectory(minhook)
 add_subdirectory(plog)
-include_directories("plog/include")
 
 find_library(shlwapi Shlwapi.lib REQUIRED)
 
@@ -30,7 +29,7 @@ file(GLOB_RECURSE sources CONFIGURE_DEPENDS "src/*.c" "src/*.cpp" "src/*.h" "src
 add_library(OpenHotfixLoader SHARED ${sources} "${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc")
 target_include_directories(OpenHotfixLoader PRIVATE "${PROJECT_BINARY_DIR}/inc" "src")
 
-target_link_libraries(OpenHotfixLoader PUBLIC minhook shlwapi cpr::cpr)
+target_link_libraries(OpenHotfixLoader PUBLIC minhook shlwapi cpr::cpr plog)
 
 # CMake by default defines NDEBUG in release, we also want the opposite
 target_compile_definitions(OpenHotfixLoader PRIVATE "$<$<CONFIG:DEBUG>:DEBUG>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ endif()
 
 add_subdirectory(cpr)
 add_subdirectory(minhook)
+add_subdirectory(plog)
+include_directories("plog/include")
 
 find_library(shlwapi Shlwapi.lib REQUIRED)
 

--- a/LICENSE
+++ b/LICENSE
@@ -786,3 +786,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+plog - Portable, simple and extensible C++ logging library
+
+MIT License
+
+Copyright (c) 2022 Sergey Podobry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -4,6 +4,8 @@
 #include "loader.h"
 #include "processing.h"
 
+static const std::string LOG_FILE_NAME = "OpenHotfixLoader.log";
+
 static HMODULE this_module;
 
 std::filesystem::path exe_path = "";
@@ -26,11 +28,13 @@ static int32_t startup_thread(void*) {
         if (GetModuleFileName(this_module, buf, sizeof(buf))) {
             dll_path = std::filesystem::path(std::wstring(buf));
         }
-        static plog::ConsoleAppender<plog::TxtFormatter> consoleAppender;
-        plog::init(plog::debug, "OpenHotfixLoader.log").addAppender(&consoleAppender);
+
+        static plog::ConsoleAppender<plog::MessageOnlyFormatter> consoleAppender;
+        plog::init(plog::debug, dll_path.replace_filename(LOG_FILE_NAME).c_str())
+            .addAppender(&consoleAppender);
 
 #ifdef DEBUG
-        LOGI << "[OHL] Running in debug mode";
+        LOGD << "[OHL] Running in debug mode";
 #endif
 
         ohl::hooks::init();
@@ -41,7 +45,7 @@ static int32_t startup_thread(void*) {
         ohl::loader::reload();
 #endif
     } catch (std::exception ex) {
-        LOGI << "[OHL] Exception occured during initalization: " << ex.what() << "\n";
+        LOGF << "[OHL] Exception occured during initalization: " << ex.what() << "\n";
     }
 
     return 1;

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -26,9 +26,11 @@ static int32_t startup_thread(void*) {
         if (GetModuleFileName(this_module, buf, sizeof(buf))) {
             dll_path = std::filesystem::path(std::wstring(buf));
         }
+        static plog::ConsoleAppender<plog::TxtFormatter> consoleAppender;
+        plog::init(plog::debug, "OpenHotfixLoader.log").addAppender(&consoleAppender);
 
 #ifdef DEBUG
-        std::cout << "[OHL] Running in debug mode";
+        LOGI << "[OHL] Running in debug mode";
 #endif
 
         ohl::hooks::init();
@@ -39,7 +41,7 @@ static int32_t startup_thread(void*) {
         ohl::loader::reload();
 #endif
     } catch (std::exception ex) {
-        std::cout << "[OHL] Exception occured during initalization: " << ex.what() << "\n";
+        LOGI << "[OHL] Exception occured during initalization: " << ex.what() << "\n";
     }
 
     return 1;

--- a/src/dllmain.h
+++ b/src/dllmain.h
@@ -1,6 +1,4 @@
 #include <pch.h>
-#include <plog/Initializers/RollingFileInitializer.h>
-#include <plog/Appenders/ConsoleAppender.h>
 
 /**
  * @brief Paths to the game exe and this dll.

--- a/src/dllmain.h
+++ b/src/dllmain.h
@@ -1,4 +1,6 @@
 #include <pch.h>
+#include <plog/Initializers/RollingFileInitializer.h>
+#include <plog/Appenders/ConsoleAppender.h>
 
 /**
  * @brief Paths to the game exe and this dll.

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -176,10 +176,11 @@ bool detour_get_verification(void* this_api,
     try {
         ohl::processing::handle_get_verification();
     } catch (std::exception ex) {
-        LOGI << "[OHL] Exception occured in get verification hook: " << ex.what() << "\n";
+        LOGE << "[OHL] Exception occured in get verification hook: " << ex.what() << "\n";
     }
 
-    return original_get_verification(this_api, uuid, consumer, platform, hardware, title, g, h, i, j);
+    return original_get_verification(this_api, uuid, consumer, platform, hardware, title, g, h, i,
+                                     j);
 }
 
 /**
@@ -194,7 +195,7 @@ bool detour_discovery_from_json(void* this_service, FJsonObject** json) {
     try {
         ohl::processing::handle_discovery_from_json(json);
     } catch (std::exception ex) {
-        LOGI << "[OHL] Exception occured in discovery hook: " << ex.what() << "\n";
+        LOGE << "[OHL] Exception occured in discovery hook: " << ex.what() << "\n";
     }
 
     return original_discovery_from_json(this_service, json);
@@ -212,7 +213,7 @@ bool detour_news_from_json(void* this_service, FJsonObject** json) {
     try {
         ohl::processing::handle_news_from_json(json);
     } catch (std::exception ex) {
-        LOGI << "[OHL] Exception occured in news hook: " << ex.what() << "\n";
+        LOGE << "[OHL] Exception occured in news hook: " << ex.what() << "\n";
     }
 
     return original_news_from_json(this_service, json);
@@ -231,7 +232,7 @@ void detour_add_image_to_cache(void* this_image_manager, TSharedPtr<FSparkReques
     try {
         may_continue = ohl::processing::handle_add_image_to_cache(req);
     } catch (std::exception ex) {
-        LOGI << "[OHL] Exception occured in image cache hook: " << ex.what() << "\n";
+        LOGE << "[OHL] Exception occured in image cache hook: " << ex.what() << "\n";
     }
 
     if (may_continue) {

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -176,7 +176,7 @@ bool detour_get_verification(void* this_api,
     try {
         ohl::processing::handle_get_verification();
     } catch (std::exception ex) {
-        std::cout << "[OHL] Exception occured in get verification hook: " << ex.what() << "\n";
+        LOGI << "[OHL] Exception occured in get verification hook: " << ex.what() << "\n";
     }
 
     return original_get_verification(this_api, uuid, consumer, platform, hardware, title, g, h, i, j);
@@ -194,7 +194,7 @@ bool detour_discovery_from_json(void* this_service, FJsonObject** json) {
     try {
         ohl::processing::handle_discovery_from_json(json);
     } catch (std::exception ex) {
-        std::cout << "[OHL] Exception occured in discovery hook: " << ex.what() << "\n";
+        LOGI << "[OHL] Exception occured in discovery hook: " << ex.what() << "\n";
     }
 
     return original_discovery_from_json(this_service, json);
@@ -212,7 +212,7 @@ bool detour_news_from_json(void* this_service, FJsonObject** json) {
     try {
         ohl::processing::handle_news_from_json(json);
     } catch (std::exception ex) {
-        std::cout << "[OHL] Exception occured in news hook: " << ex.what() << "\n";
+        LOGI << "[OHL] Exception occured in news hook: " << ex.what() << "\n";
     }
 
     return original_news_from_json(this_service, json);
@@ -231,7 +231,7 @@ void detour_add_image_to_cache(void* this_image_manager, TSharedPtr<FSparkReques
     try {
         may_continue = ohl::processing::handle_add_image_to_cache(req);
     } catch (std::exception ex) {
-        std::cout << "[OHL] Exception occured in image cache hook: " << ex.what() << "\n";
+        LOGI << "[OHL] Exception occured in image cache hook: " << ex.what() << "\n";
     }
 
     if (may_continue) {
@@ -344,7 +344,7 @@ void init(void) {
         throw std::runtime_error("MH_EnableHook failed " + std::to_string(ret));
     }
 
-    std::cout << "[OHL] Hooks injected successfully\n";
+    LOGI << "[OHL] Hooks injected successfully\n";
 }
 
 }  // namespace ohl::hooks

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -324,6 +324,7 @@ static void load_mod_file(const std::filesystem::path& path,
 
     std::ifstream stream{path};
     if (!stream.is_open()) {
+        LOGE << L"[OHL]: Error opening file '" << path << "'\n";
         return;
     }
 
@@ -354,11 +355,10 @@ static void load_mod_url(const std::wstring& url,
     auto resp = cpr::Get(cpr::Url{narrow_url}, cpr::AcceptEncoding{{""}});
 
     if (resp.status_code == 0) {
-        LOGI << "[OHL] Error downloading '" << narrow_url << "': " << resp.error.message
-             << "\n";
+        LOGE << "[OHL] Error downloading '" << narrow_url << "': " << resp.error.message << "\n";
         return;
     } else if (resp.status_code >= 400) {
-        LOGI << "[OHL] Error downloading '" << narrow_url << "': " << resp.status_code << "\n";
+        LOGE << "[OHL] Error downloading '" << narrow_url << "': " << resp.status_code << "\n";
         return;
     }
 

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -354,11 +354,11 @@ static void load_mod_url(const std::wstring& url,
     auto resp = cpr::Get(cpr::Url{narrow_url}, cpr::AcceptEncoding{{""}});
 
     if (resp.status_code == 0) {
-        std::cout << "[OHL] Error downloading '" << narrow_url << "': " << resp.error.message
-                  << "\n";
+        LOGI << "[OHL] Error downloading '" << narrow_url << "': " << resp.error.message
+             << "\n";
         return;
     } else if (resp.status_code >= 400) {
-        std::cout << "[OHL] Error downloading '" << narrow_url << "': " << resp.status_code << "\n";
+        LOGI << "[OHL] Error downloading '" << narrow_url << "': " << resp.status_code << "\n";
         return;
     }
 
@@ -478,7 +478,7 @@ static void reload_impl(void) {
 
     injected_news_items.push_front(get_ohl_news_item());
 
-    std::wcout << L"[OHL] " << injected_news_items[0].body << "\n";
+    LOGI << L"[OHL] " << injected_news_items[0].body << "\n";
 }
 
 void init(void) {

--- a/src/pch.h
+++ b/src/pch.h
@@ -8,6 +8,7 @@
 
 #ifdef __cplusplus
 #include <cpr/cpr.h>
+#include <plog/Log.h>
 
 #include <array>
 #include <codecvt>

--- a/src/pch.h
+++ b/src/pch.h
@@ -8,6 +8,9 @@
 
 #ifdef __cplusplus
 #include <cpr/cpr.h>
+#include <plog/Appenders/ConsoleAppender.h>
+#include <plog/Formatters/MessageOnlyFormatter.h>
+#include <plog/Initializers/RollingFileInitializer.h>
 #include <plog/Log.h>
 
 #include <array>

--- a/src/processing.cpp
+++ b/src/processing.cpp
@@ -221,7 +221,7 @@ void init(void) {
 }
 
 void handle_get_verification(void) {
-    std::wcout << L"[OHL] Starting to reload mods\n";
+    LOGI << L"[OHL] Starting to reload mods\n";
     ohl::loader::reload();
 }
 
@@ -271,7 +271,7 @@ void handle_discovery_from_json(FJsonObject** json) {
 
     params->entries.count = new_hotfix_count;
 
-    std::cout << "[OHL] Injected hotfixes\n";
+    LOGI << "[OHL] Injected hotfixes\n";
 
     if (dump_hotfixes) {
         // For some god forsaken reason the default behaviour of **w**ofstream is to output ascii.
@@ -304,7 +304,7 @@ void handle_discovery_from_json(FJsonObject** json) {
             dump.put(0x00);
         }
         dump.close();
-        std::cout << "[OHL] Dumped hotfixes to file\n";
+        LOGI << "[OHL] Dumped hotfixes to file\n";
     }
 }
 
@@ -364,7 +364,7 @@ void handle_news_from_json(ohl::unreal::FJsonObject** json) {
 
     news_data->entries.count = new_news_data_size;
 
-    std::cout << "[OHL] Injected news\n";
+    LOGI << "[OHL] Injected news\n";
 }
 
 bool handle_add_image_to_cache(TSharedPtr<FSparkRequest>* req) {
@@ -376,7 +376,7 @@ bool handle_add_image_to_cache(TSharedPtr<FSparkRequest>* req) {
                         }) == news_items.end();
 
     if (!may_continue) {
-        std::wcout << L"[OHL] Prevented news icon from being cached: " << url << L"\n";
+        LOGI << L"[OHL] Prevented news icon from being cached: " << url << L"\n";
     }
 
     return may_continue;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7,7 +7,8 @@ std::string narrow(const std::wstring& wstr) {
         return std::string();
     }
 
-    auto num_chars = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), wstr.size(), NULL, 0, NULL, NULL);
+    auto num_chars =
+        WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), wstr.size(), NULL, 0, NULL, NULL);
     char* str = reinterpret_cast<char*>(malloc((num_chars + 1) * sizeof(char)));
     if (!str) {
         throw std::runtime_error("Failed to convert utf16 string!");


### PR DESCRIPTION
Given our prior discussion #4  I thought I'd try out loguru as you suggested, it did not like wstrings and required a lot of work just to convert wstrings to utf-8 strings. I would've been easier had it worked but they have no support for wstrings.

So I found cmake friendly `plog` which had wstring support and tried to integrate it.

I integrated plog and it logs to console and to a log file.

The formatting should be fine, nothing much changed, it is a stream style logger. 

* I did not address moving the log file anywhere because loader.cpp had a lot of logic for that which would require quite a lot more work.
* I did not compile for windows so I did not integrate or check to see if it worked (again on Linux).

So please check if this works for you.

Regardless, I was able to briefly test plog's ability with this (it is obviously from their tutorial but it did work).
```
#include "pch.h"
#include <plog/Log.h> // Step1: include the headers
#include <plog/Initializers/RollingFileInitializer.h>
#include <plog/Appenders/ConsoleAppender.h>

int main(int argc, char ** argv) {
    static plog::ConsoleAppender<plog::TxtFormatter> consoleAppender;
    plog::init(plog::debug, "Hello.txt").addAppender(&consoleAppender);
    PLOGD << "Hello log!"; // short macro
    PLOG_DEBUG << "Hello log!"; // long macro
    PLOG(plog::debug) << "Hello log!"; // function-style macro
    LOGD << "Hello log!"; // short macro
    LOG_DEBUG << "Hello log!"; // long macro
    LOG(plog::debug) << "Hello log!"; // function-style macro

    std::runtime_error ex("Exception Text");
    std::wstring path = L"/etc";
    LOGI <<  "[OHL] Running in debug mode" ;
    LOGI <<  "[OHL] Exception occured during initalization: " << ex.what() ;
    LOGI <<  "[OHL] Exception occured in discovery hook: " << ex.what() ;
    LOGI <<  "[OHL] Exception occured in news hook: " << ex.what() ;
    LOGI <<  "[OHL] Exception occured in image hook: " << ex.what() ;
    LOGI <<  "[OHL] Hooks injected successfully" ;
    LOGI <<  "[OHL] Failed to open file '"<< path << "'!";
    LOGI <<  "[OHL] Injected hotfixes" ;
    LOGI <<  "[OHL] Dumped hotfixes to file" ;
    LOGI <<  "Didn't find vf tables in time!";
    LOGI <<  "[OHL] Injected news" ;
    LOGI <<  "[OHL] Prevented news icon from being cached" ;
    return 0;
}

```

# Motivation

Please understand that the motivation is that Linux users using steam or lutris are unlikely to have console access and unlikely to want to replicate the environment that Lutris or Steam provides just in order to get console access. Having a log file means we can monitor mod progress without console access.